### PR TITLE
Add Codespaces automation for frontend and backend servers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+{
+  "name": "Mcp-server Codespace",
+  "image": "mcr.microsoft.com/devcontainers/python:3.12",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "20"
+    }
+  },
+  "postCreateCommand": ".devcontainer/post-create.sh",
+  "postAttachCommand": ".devcontainer/start-services.sh",
+  "forwardPorts": [8000, 5173],
+  "portsAttributes": {
+    "8000": {
+      "label": "Django API",
+      "onAutoForward": "silent"
+    },
+    "5173": {
+      "label": "Frontend UI",
+      "onAutoForward": "openBrowser"
+    }
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "python.defaultInterpreterPath": "/usr/local/bin/python",
+        "python.envFile": "${workspaceFolder}/.env"
+      },
+      "extensions": [
+        "ms-python.python",
+        "ms-python.vscode-pylance",
+        "ms-toolsai.jupyter",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+cd "$ROOT_DIR"
+
+python -m pip install --upgrade pip
+python -m pip install -r requirements.txt
+npm install --prefix frontend

--- a/.devcontainer/start-services.sh
+++ b/.devcontainer/start-services.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="$ROOT_DIR/.devcontainer/logs"
+mkdir -p "$LOG_DIR"
+
+cd "$ROOT_DIR"
+
+start_django() {
+  if pgrep -f "manage.py runserver" >/dev/null; then
+    echo "Django server already running"
+  else
+    echo "Starting Django development server..."
+    nohup python manage.py runserver 0.0.0.0:8000 \
+      >"$LOG_DIR/django.log" 2>&1 &
+  fi
+}
+
+start_frontend() {
+  if pgrep -f "npm run dev" >/dev/null; then
+    echo "Vite dev server already running"
+  else
+    echo "Starting Vite development server..."
+    cd "$ROOT_DIR/frontend"
+    nohup npm run dev -- --host 0.0.0.0 --port 5173 \
+      >"$LOG_DIR/frontend.log" 2>&1 &
+  fi
+}
+
+start_django
+start_frontend
+
+cd "$ROOT_DIR"

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Django settings
+DJANGO_SECRET_KEY=change-me
+DJANGO_DEBUG=True
+# Comma separated list of hosts allowed by Django. Leave empty to allow all hosts in debug mode.
+DJANGO_ALLOWED_HOSTS=
+
+# OpenAI configuration
+OPENAI_API_KEY=
+OPENAI_BASE_URL=https://api.openai.com/v1
+OPENAI_MODEL=gpt-4o-mini
+
+# Frontend development server overrides (optional)
+MCP_DEVSERVER_HOST=0.0.0.0
+MCP_DEVSERVER_PORT=5173
+MCP_PROXY_TARGET=http://localhost:8000

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -4,10 +4,15 @@ import react from '@vitejs/plugin-react';
 export default ({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const proxyTarget = env.MCP_PROXY_TARGET || 'http://localhost:8000';
+  const host = env.MCP_DEVSERVER_HOST || '0.0.0.0';
+  const port = parseInt(env.MCP_DEVSERVER_PORT || '5173', 10);
 
   return defineConfig({
     plugins: [react()],
     server: {
+      host,
+      port,
+      strictPort: true,
       proxy: {
         '/mcp/': {
           target: proxyTarget,

--- a/mcp_server/settings.py
+++ b/mcp_server/settings.py
@@ -13,20 +13,37 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 import os
 from pathlib import Path
 
+from dotenv import load_dotenv
+
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
+
+load_dotenv(BASE_DIR / ".env")
+
+
+def str_to_bool(value: str | bool) -> bool:
+    if isinstance(value, bool):
+        return value
+    return value.lower() in {"1", "true", "t", "yes", "y", "on"}
 
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "django-insecure-@^@febiqu-_6$7ni#8f^%bgje&!47ufj^wfj=_y4q!cv)y@b_j"
+SECRET_KEY = os.getenv(
+    "DJANGO_SECRET_KEY",
+    "django-insecure-@^@febiqu-_6$7ni#8f^%bgje&!47ufj^wfj=_y4q!cv)y@b_j",
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = str_to_bool(os.getenv("DJANGO_DEBUG", "True"))
 
-ALLOWED_HOSTS = []
+allowed_hosts = os.getenv("DJANGO_ALLOWED_HOSTS", "")
+if allowed_hosts:
+    ALLOWED_HOSTS = [host.strip() for host in allowed_hosts.split(",") if host.strip()]
+else:
+    ALLOWED_HOSTS = ["*"] if DEBUG else []
 
 
 # Application definition

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Django==5.2.7
 openai==2.6.0
+python-dotenv==1.0.1


### PR DESCRIPTION
## Summary
- add a devcontainer configuration that installs dependencies, forwards ports, and wires VS Code to the project .env file
- provide automation scripts to boot the Django and Vite development servers automatically inside GitHub Codespaces
- load Django settings from environment variables, document supported values, and make the Vite dev server reachable from Codespaces

## Testing
- python manage.py check

------
https://chatgpt.com/codex/tasks/task_e_68f7f89e7c408320846357fc5cf7e351